### PR TITLE
secret_scanning.go: API fix by switching arugments from url to json

### DIFF
--- a/github/secret_scanning.go
+++ b/github/secret_scanning.go
@@ -53,14 +53,14 @@ type SecretScanningAlertLocationDetails struct {
 // SecretScanningAlertListOptions specifies optional parameters to the SecretScanningService.ListAlertsForEnterprise method.
 type SecretScanningAlertListOptions struct {
 	// State of the secret scanning alerts to list. Set to open or resolved to only list secret scanning alerts in a specific state.
-	State string `url:"state,omitempty"`
+	State string `json:"state,omitempty"`
 
 	// A comma-separated list of secret types to return. By default all secret types are returned.
-	SecretType string `url:"secret_type,omitempty"`
+	SecretType string `json:"secret_type,omitempty"`
 
 	// A comma-separated list of resolutions. Only secret scanning alerts with one of these resolutions are listed.
 	// Valid resolutions are false_positive, wont_fix, revoked, pattern_edited, pattern_deleted or used_in_tests.
-	Resolution string `url:"resolution,omitempty"`
+	Resolution string `json:"resolution,omitempty"`
 
 	ListCursorOptions
 
@@ -77,14 +77,14 @@ type SecretScanningAlertListOptions struct {
 type SecretScanningAlertUpdateOptions struct {
 	// Required. Sets the state of the secret scanning alert. Can be either open or resolved.
 	// You must provide resolution when you set the state to resolved.
-	State *string `url:"state,omitempty"`
+	State *string `json:"state,omitempty"`
 
 	// A comma-separated list of secret types to return. By default all secret types are returned.
-	SecretType *string `url:"secret_type,omitempty"`
+	SecretType *string `json:"secret_type,omitempty"`
 
 	// Required when the state is resolved. The reason for resolving the alert. Can be one of false_positive,
 	// wont_fix, revoked, or used_in_tests.
-	Resolution *string `url:"resolution,omitempty"`
+	Resolution *string `json:"resolution,omitempty"`
 }
 
 // Lists secret scanning alerts for eligible repositories in an enterprise, from newest to oldest.


### PR DESCRIPTION
These structs were incorrectly defined with `url` parameters, instead these need to be encoded into `json` for the request.